### PR TITLE
HOTFIX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,17 +85,6 @@
       <url>http://repo.spring.io/milestone</url>
     </repository>
   </repositories>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-gcp-dependencies</artifactId>
-        <version>1.0.0.RC1</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <build>
     <finalName>${project.artifactId}</finalName>


### PR DESCRIPTION
Removed DependencyManagement and its contents from POM.xml as it was preventing the Jenkins build from working